### PR TITLE
Can't donwload vagrant image box

### DIFF
--- a/ensembl/rest/Vagrantfile
+++ b/ensembl/rest/Vagrantfile
@@ -11,6 +11,7 @@ ENSEMBL_API_VERSION = ENV['ENSEMBL_API_VERSION'] || "80"
 TEST_ENV = 'true'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
   config.vm.box = "hashicorp/precise64"
   # :guest == VM
   # :host == local machine


### PR DESCRIPTION
I'll try to install ensembl code base with vargant from https://github.com/Ensembl/ensembl-rest/blob/release/83/INSTALL.md

So we should improve documentation(manually set vagrant image box url) or merge my patch

$ vagrant up

Bringing machine 'default' up with 'virtualbox' provider...
There are errors in the configuration of this machine. Please fix
the following errors and try again:

vm:
- The box 'hashicorp/precise64' could not be found.

$ vagrant -v
Vagrant 1.4.3
